### PR TITLE
Enhancement/test suite

### DIFF
--- a/clippings/parser.py
+++ b/clippings/parser.py
@@ -121,7 +121,7 @@ class Metadata:
         location = Location.parse(match.group('location'))
         timestamp = dateutil.parser.parse(match.group('timestamp'))
         try:
-            page = match.group('page')
+            page = int(match.group('page'))
         except TypeError:
             page = None
         return cls(category, location, timestamp, page)

--- a/clippings/parser.py
+++ b/clippings/parser.py
@@ -59,6 +59,9 @@ class Location:
         else:
             return '{0}-{1}'.format(self.begin, self.end)
 
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
+
     def to_dict(self):
         return self.__dict__
 

--- a/tests/parser_test.py
+++ b/tests/parser_test.py
@@ -1,6 +1,7 @@
 import unittest
 
 from clippings.parser import Document
+from clippings.parser import Location
 
 
 class DocumentTest(unittest.TestCase):
@@ -54,3 +55,48 @@ class DocumentTest(unittest.TestCase):
             'authors': authors
         }
         self.assertEqual(expected_dict, document.to_dict())
+
+
+class LocationTest(unittest.TestCase):
+
+    BEGIN = 666
+    END = 1337
+    SINGLE_LOCATION_STRING = '666'
+    RANGE_LOCATION_STRING = '666-1337'
+
+    def test_create_location(self):
+        location = Location(self.BEGIN, self.END)
+        self.assertEqual(self.BEGIN, location.begin)
+        self.assertEqual(self.END, location.end)
+
+    def test_parse_range_location(self):
+        location_string = self.RANGE_LOCATION_STRING
+        location = Location.parse(location_string)
+        self.assertTrue(isinstance(location.begin, int))
+        self.assertTrue(isinstance(location.end, int))
+        self.assertEqual(self.BEGIN, location.begin)
+        self.assertEqual(self.END, location.end)
+
+    def test_parse_single_location(self):
+        location_string = self.SINGLE_LOCATION_STRING
+        location = Location.parse(location_string)
+        self.assertTrue(isinstance(location.begin, int))
+        self.assertTrue(isinstance(location.end, int))
+        self.assertEqual(self.BEGIN, location.begin)
+        self.assertEqual(self.BEGIN, location.end)
+
+    def test_location_to_dict(self):
+        location = Location(self.BEGIN, self.END)
+        expected_dictionary = {
+            'begin': self.BEGIN,
+            'end': self.END,
+        }
+        self.assertEqual(expected_dictionary, location.to_dict())
+
+    def test_range_location_to_str(self):
+        location = Location(self.BEGIN, self.BEGIN)
+        self.assertEqual(self.SINGLE_LOCATION_STRING, str(location))
+
+    def test_single_location_to_str(self):
+        location = Location(self.BEGIN, self.END)
+        self.assertEqual(self.RANGE_LOCATION_STRING, str(location))

--- a/tests/parser_test.py
+++ b/tests/parser_test.py
@@ -1,6 +1,9 @@
 import datetime
 import unittest
 
+from unittest.mock import MagicMock
+
+from clippings.parser import Clipping
 from clippings.parser import Document
 from clippings.parser import Location
 from clippings.parser import Metadata
@@ -213,3 +216,45 @@ class MetadataTest(unittest.TestCase):
         self.assertEqual(datetime.datetime(2016, 9, 13, 7, 29, 9),
                          metadata.timestamp)
         self.assertEqual(None, metadata.page)
+
+
+class ClippingTest(unittest.TestCase):
+
+    def test_create_clipping(self):
+        document = MagicMock()
+        metadata = MagicMock()
+        content = 'Some content'
+
+        clipping = Clipping(document, metadata, content)
+
+        self.assertEqual(document, clipping.document)
+        self.assertEqual(metadata, clipping.metadata)
+        self.assertEqual(content, clipping.content)
+
+    def test_clipping_to_str(self):
+        document = MagicMock()
+        document.__str__ = MagicMock(return_value='Title (Author)')
+        metadata = MagicMock()
+        metadata.__str__ = MagicMock(return_value='SO META!')
+        content = 'Some content'
+
+        expected_string = "Title (Author)\nSO META!\nSome content"
+
+        clipping = Clipping(document, metadata, content)
+        self.assertEqual(expected_string, str(clipping))
+
+    def test_clipping_to_dict(self):
+        document = MagicMock()
+        document.to_dict = MagicMock(return_value={'doc': 'ument'})
+        metadata = MagicMock()
+        metadata.to_dict = MagicMock(return_value={'meta': 'data'})
+        content = 'Some content'
+
+        expected_dict = {
+            'content': 'Some content',
+            'document': {'doc': 'ument'},
+            'metadata': {'meta': 'data'},
+        }
+
+        clipping = Clipping(document, metadata, content)
+        self.assertEqual(expected_dict, clipping.to_dict())

--- a/tests/parser_test.py
+++ b/tests/parser_test.py
@@ -1,0 +1,56 @@
+import unittest
+
+from clippings.parser import Document
+
+
+class DocumentTest(unittest.TestCase):
+
+    def test_create_document(self):
+        title = 'Haunted'
+        authors = ['Chuck Palahniuk']
+        document = Document(title, authors)
+
+        self.assertEqual(title, document.title)
+        self.assertEqual(authors, document.authors)
+
+    def test_parse_document_with_single_author(self):
+        document_line = '1984 (George Orwell)'
+        document = Document.parse(document_line)
+
+        expected_authors = ['George Orwell']
+        self.assertEqual(expected_authors, document.authors)
+
+        expected_title = '1984'
+        self.assertEqual(expected_title, document.title)
+
+    def test_parse_document_with_multiple_authors(self):
+        document_line = 'Java Concurrency in Practice (Joshua Bloch;Brian Goetz)'
+        document = Document.parse(document_line)
+
+        expected_authors = [
+            'Joshua Bloch',
+            'Brian Goetz',
+        ]
+        self.assertEqual(expected_authors, document.authors)
+
+        expected_title = 'Java Concurrency in Practice'
+        self.assertEqual(expected_title, document.title)
+
+    def test_document_to_string(self):
+        title = 'Also sprach Zarathustra'
+        authors = ['Friedrich Nietzsche']
+        document = Document(title, authors)
+
+        expected_string = 'Also sprach Zarathustra (Friedrich Nietzsche)'
+        self.assertEqual(expected_string, str(document))
+
+    def test_document_to_dict(self):
+        title = 'À la recherche du temps perdu'
+        authors = ['Marcel Proust']
+        document = Document(title, authors)
+
+        expected_dict = {
+            'title': title,
+            'authors': authors
+        }
+        self.assertEqual(expected_dict, document.to_dict())

--- a/tests/parser_test.py
+++ b/tests/parser_test.py
@@ -89,11 +89,11 @@ class LocationTest(unittest.TestCase):
 
     def test_location_to_dict(self):
         location = Location(self.BEGIN, self.END)
-        expected_dictionary = {
+        expected_dict = {
             'begin': self.BEGIN,
             'end': self.END,
         }
-        self.assertEqual(expected_dictionary, location.to_dict())
+        self.assertEqual(expected_dict, location.to_dict())
 
     def test_range_location_to_str(self):
         location = Location(self.BEGIN, self.BEGIN)

--- a/tests/parser_test.py
+++ b/tests/parser_test.py
@@ -100,3 +100,22 @@ class LocationTest(unittest.TestCase):
     def test_single_location_to_str(self):
         location = Location(self.BEGIN, self.END)
         self.assertEqual(self.RANGE_LOCATION_STRING, str(location))
+
+    def test_equality_same_values(self):
+        l1 = Location(self.BEGIN, self.END)
+        l2 = Location(self.BEGIN, self.END)
+        self.assertFalse(l1 is l2)
+        self.assertTrue(l1 == l2)
+
+    def test_equality_different_values(self):
+        l1 = Location(self.BEGIN, self.END)
+        l2 = Location(self.BEGIN, self.END + 1)
+        self.assertFalse(l1 == l2)
+
+        l2 = Location(self.BEGIN + 1, self.END)
+        self.assertFalse(l1 == l2)
+
+    def test_equality_different_types(self):
+        l1 = Location(self.BEGIN, self.END)
+        l2 = (self.BEGIN, self.END)
+        self.assertFalse(l1 == l2)

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,0 +1,24 @@
+import datetime
+import json
+import unittest
+
+from clippings.utils import DatetimeJSONEncoder
+
+
+DATE = datetime.datetime(2016, 1, 2, 3, 4, 5)
+DATE_STRING = "2016-01-02T03:04:05"
+
+
+class DatetimeJSONEncoderTest(unittest.TestCase):
+
+    def test_datetime_encoder_format(self):
+        dictionary = {"now": DATE}
+        expected_json_string = json.dumps({"now": DATE_STRING})
+        json_string = json.dumps(dictionary, cls=DatetimeJSONEncoder)
+        self.assertEqual(expected_json_string, json_string)
+
+    def test_datetime_encoder_typeerror(self):
+        undumpable_dictionary = {"set": set()}
+        # Ensure we let the parent raise TypeError
+        with self.assertRaises(TypeError):
+            json_string = json.dumps(undumpable_dictionary, cls=DatetimeJSONEncoder)


### PR DESCRIPTION
Add a test suite for the classes in the parser and utils modules.

The main functions are not tested yet, but there is some refactoring
and fixing to do beforehand.

Tests are only python3 (for now), as they are using new assertion methods,
and the unittest.mock module.

Also fixed a buggy conversion, where the page was a string and not an int.