### PR TITLE
Don't parse multiple authors string into list

### DIFF
--- a/clippings/parser.py
+++ b/clippings/parser.py
@@ -17,20 +17,18 @@ CLIPPINGS_SEPARATOR = '=========='
 class Document(BasicEqualityMixin):
     """Document (e.g. book, article) the clipping originates from.
 
-    A document has a title, and a list of authors.
+    A document has a title, and one or multiple authors (in a string).
     """
 
     PATTERN = re.compile(r'^(?P<title>.+) \((?P<authors>.+?)\)$')
-    AUTHORS_SEPARATOR = ';'
 
     def __init__(self, title, authors):
         self.title = title
         self.authors = authors
 
     def __str__(self):
-        authors_string = self.AUTHORS_SEPARATOR.join(self.authors)
         return '{title} ({authors})'.format(title=self.title,
-                                            authors=authors_string)
+                                            authors=self.authors)
 
     def to_dict(self):
         return self.__dict__
@@ -39,8 +37,7 @@ class Document(BasicEqualityMixin):
     def parse(cls, line):
         match = re.match(cls.PATTERN, line)
         title = match.group('title')
-        authors_string = match.group('authors')
-        authors = authors_string.split(cls.AUTHORS_SEPARATOR)
+        authors = match.group('authors')
         return cls(title, authors)
 
 

--- a/tests/parser_test.py
+++ b/tests/parser_test.py
@@ -36,7 +36,7 @@ class DocumentTest(unittest.TestCase, DefaultObjectFactoryMixin):
 
     defaults = {
         'title': '1984',
-        'authors': ['George Orwell'],
+        'authors': 'George Orwell',
     }
 
     default_object_string = '1984 (George Orwell)'
@@ -46,15 +46,10 @@ class DocumentTest(unittest.TestCase, DefaultObjectFactoryMixin):
         self.assertEqual(self.defaults['title'], document.title)
         self.assertEqual(self.defaults['authors'], document.authors)
 
-    def test_parse_document_with_single_author(self):
+    def test_parse_document(self):
         document = Document.parse(self.default_object_string)
         self.assertEqual(self.defaults['authors'], document.authors)
         self.assertEqual(self.defaults['title'], document.title)
-
-    def test_parse_document_with_multiple_authors(self):
-        document = Document.parse('1984 (Joshua Bloch;Brian Goetz)')
-        self.assertEqual(self.defaults['title'], document.title)
-        self.assertEqual(['Joshua Bloch', 'Brian Goetz'], document.authors)
 
     def test_document_to_string(self):
         document = self.get_default_object()
@@ -72,7 +67,7 @@ class DocumentTest(unittest.TestCase, DefaultObjectFactoryMixin):
 
     def test_equality_different_values(self):
         document1 = self.get_default_object()
-        document2 = self.get_default_object(authors=['Lewis Carroll'])
+        document2 = self.get_default_object(authors='Lewis Carroll')
         self.assertNotEqual(document1, document2)
 
     def test_equality_different_types(self):


### PR DESCRIPTION
The format doesn't seem to be standard, and it's better not to
try and parse it, than doing it wrong and have unexpected results.