### PR TITLE
Feature/console script

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,11 @@ Change Log
 This document tracks changes to `clippings <https://pypi.python.org/pypi/clippings>`_ between releases.
 
 
+`0.3.0`_ (2017-01-19)
+---------------------
+
+* [feature] Add a 'clippings' console script.
+
 `0.2.1`_ (2017-01-08)
 ---------------------
 
@@ -50,3 +55,4 @@ This document tracks changes to `clippings <https://pypi.python.org/pypi/clippin
 .. _`0.1.2`: https://github.com/samueldg/clippings/compare/0.1.1...0.1.2
 .. _`0.2.0`: https://github.com/samueldg/clippings/compare/0.1.2...0.2.0
 .. _`0.2.1`: https://github.com/samueldg/clippings/compare/0.2.0...0.2.1
+.. _`0.3.0`: https://github.com/samueldg/clippings/compare/0.2.1...0.3.0

--- a/README.rst
+++ b/README.rst
@@ -23,10 +23,10 @@ Usage
 .. code:: shell
 
     # Parse a clippings file
-    python -m clippings.parser -o dict ./clippings.txt
+    clippings -o dict ./clippings.txt
     
     # or from stdin:
-    cat clippings.txt | python -m clippings.parser -
+    cat clippings.txt | clippings -
 
 
 .. |pypi| image:: https://img.shields.io/pypi/v/clippings.svg

--- a/clippings/__init__.py
+++ b/clippings/__init__.py
@@ -1,3 +1,3 @@
 """Python module to manipulate Kindle clippings files."""
 
-__version__ = '0.2.1'
+__version__ = '0.3.0'

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,11 @@ setup(
     packages=[
         'clippings'
     ],
+    entry_points={
+        'console_scripts': [
+            'clippings = clippings.parser:main',
+        ],
+    },
     include_package_data=True,
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
Add a 'clippings' console script, to simplify CLI usage.

What used to be:

```shell
python -m clippings.parser my_file.txt
```

is now:

```shell
clippings my_file.txt
```

Also bumped to 0.3.0