### PR TITLE
Update Python support: +3.7, -3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,11 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-sudo: false
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
 install:
   - pip install tox-travis coveralls
 script:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,13 @@ Change Log
 This document tracks changes to `clippings <https://pypi.python.org/pypi/clippings>`_ between releases.
 
 
+`0.4.0`_ (2018-01-08)
+---------------------
+
+* [dist] Officially drop support for Python 3.3.
+* [dist] Add support for Python 3.7, and include in CI.
+* [fix] Fix Travis CI build, which no longer supported Python 3.3.
+
 `0.3.0`_ (2017-01-19)
 ---------------------
 
@@ -56,3 +63,4 @@ This document tracks changes to `clippings <https://pypi.python.org/pypi/clippin
 .. _`0.2.0`: https://github.com/samueldg/clippings/compare/0.1.2...0.2.0
 .. _`0.2.1`: https://github.com/samueldg/clippings/compare/0.2.0...0.2.1
 .. _`0.3.0`: https://github.com/samueldg/clippings/compare/0.2.1...0.3.0
+.. _`0.4.0`: https://github.com/samueldg/clippings/compare/0.3.0...0.4.0

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from clippings import __version__
 
 
 requirements = [
-    'python-dateutil==2.6.0',
+    'python-dateutil==2.7.5',
 ]
 
 if sys.version_info[0] == 2:

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Utilities',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36
+envlist = py27,py34,py35,py36,py37
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,py35,py36
+envlist = py27,py34,py35,py36
 
 [testenv]
 deps =


### PR DESCRIPTION
Add support for Python 3.7 (in CI + trove classifiers) and drop 3.3.

Also bump the dateutil dependency.