### PR TITLE
Release 0.5.0: +py38, -py27, -py34

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,6 @@ __pycache__/
 *.py[cod]
 *$py.class
 
-# C extensions
-*.so
-
 # Distribution / packaging
 .Python
 env/
@@ -24,33 +21,14 @@ var/
 .installed.cfg
 *.egg
 
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
-
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
-
 # Unit test / coverage reports
 htmlcov/
 .tox/
 .coverage
 .coverage.*
 .cache
-junit-*.xml
 
 # virtualenv
 venv/
 .venv/
 ENV/
-
-# Mac OS
-.DS_Store
-
-# Sublime Text
-*.sublime-build
-*.sublime-project
-*.sublime-workspace

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,9 @@
 language: python
 python:
-  - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
-matrix:
-  include:
-    - python: 3.7
-      dist: xenial
-      sudo: true
+  - "3.7"
+  - "3.8"
 install:
   - pip install tox-travis coveralls
 script:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,13 @@ Change Log
 This document tracks changes to `clippings <https://pypi.python.org/pypi/clippings>`_ between releases.
 
 
+`0.5.0`_ (2019-11-24)
+---------------------
+
+* [dist] Drop support for Python 2.7.
+* [dist] Drop support for Python 3.4.
+* [dist] Add support for Python 3.8, and include in CI.
+
 `0.4.0`_ (2018-01-08)
 ---------------------
 
@@ -64,3 +71,4 @@ This document tracks changes to `clippings <https://pypi.python.org/pypi/clippin
 .. _`0.2.1`: https://github.com/samueldg/clippings/compare/0.2.0...0.2.1
 .. _`0.3.0`: https://github.com/samueldg/clippings/compare/0.2.1...0.3.0
 .. _`0.4.0`: https://github.com/samueldg/clippings/compare/0.3.0...0.4.0
+.. _`0.5.0`: https://github.com/samueldg/clippings/compare/0.4.0...0.5.0

--- a/clippings/parser.py
+++ b/clippings/parser.py
@@ -1,6 +1,4 @@
 """Parser for Amazon Kindle clippings file"""
-from __future__ import print_function
-
 import argparse
 import json
 import re

--- a/setup.py
+++ b/setup.py
@@ -8,13 +8,10 @@ with open('clippings/__init__.py') as f:
     # Not importing the file in setup.py!
     VERSION = re.search(r"__version__ = '(?P<version>.*?)'", f.read()).group('version')
 
-requirements = [
-    'python-dateutil==2.7.5',
+
+REQUIREMENTS = [
+    'python-dateutil~=2.7',
 ]
-
-if sys.version_info[0] == 2:
-    requirements.append('mock==2.0.0')
-
 
 setup(
     name='clippings',
@@ -23,7 +20,7 @@ setup(
     long_description=(open('README.rst').read()),
     url='http://github.com/samueldg/clippings/',
     download_url = 'https://github.com/samueldg/clippings/tarball/' + VERSION,
-    install_requires=requirements,
+    install_requires=REQUIREMENTS,
     license='MIT',
     author='Samuel Dion-Girardeau',
     author_email='samuel.diongirardeau@gmail.com',
@@ -42,13 +39,11 @@ setup(
         'Natural Language :: English',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Utilities',
     ],

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,12 @@
+import re
 import sys
 
 from setuptools import setup
 
-from clippings import __version__
 
+with open('clippings/__init__.py') as f:
+    # Not importing the file in setup.py!
+    VERSION = re.search(r"__version__ = '(?P<version>.*?)'", f.read()).group('version')
 
 requirements = [
     'python-dateutil==2.7.5',
@@ -15,11 +18,11 @@ if sys.version_info[0] == 2:
 
 setup(
     name='clippings',
-    version=__version__,
+    version=VERSION,
     description='Amazon Kindle clippings parser',
     long_description=(open('README.rst').read()),
     url='http://github.com/samueldg/clippings/',
-    download_url = 'https://github.com/samueldg/clippings/tarball/' + __version__,
+    download_url = 'https://github.com/samueldg/clippings/tarball/' + VERSION,
     install_requires=requirements,
     license='MIT',
     author='Samuel Dion-Girardeau',

--- a/tests/parser_test.py
+++ b/tests/parser_test.py
@@ -3,11 +3,7 @@ import json
 import os.path
 import sys
 import unittest
-
-try:
-    import unittest.mock as mock
-except ImportError:
-    import mock
+from unittest import mock
 
 from clippings.parser import Clipping
 from clippings.parser import Document

--- a/tests/utils/context.py
+++ b/tests/utils/context.py
@@ -1,20 +1,7 @@
 import sys
-
 from contextlib import contextmanager
-
-try:
-    # Python 2
-    from StringIO import StringIO
-except ImportError:
-    # Python 3
-    from io import StringIO
-
-try:
-    # Python 3
-    import unittest.mock as mock
-except ImportError:
-    # Python 2
-    import mock
+from io import StringIO
+from unittest.mock import patch
 
 
 @contextmanager
@@ -28,7 +15,7 @@ def cli_args(arg_list):
         python -m clippings.parser test.txt -o dict
     """
     mock_argv = ['clippings.py'] + arg_list
-    with mock.patch.object(sys, 'argv', mock_argv):
+    with patch.object(sys, 'argv', mock_argv):
         yield
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,py37
+envlist = py35,py36,py37,py38
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -8,4 +8,4 @@ deps =
     coverage
     coveralls
 commands =
-    py.test --cov clippings --cov-report term-missing
+    pytest --cov clippings --cov-report term-missing


### PR DESCRIPTION
* Drop support for Python 2.7.
* Drop support for Python 3.4.
* Add support for Python 3.8, and include in CI.
* Update changelog