### PR TITLE
Language support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,9 +54,6 @@ Here's a highlight clipping taken from a Kindle that speaks Spanish::
 the second line and pass it to the parameter ``metadata_parser``. 
 You can take a look at an example `here <examples/bilingual_spanish_english_kindle/main.py>`_.
 
-
-
-
 .. |pypi| image:: https://img.shields.io/pypi/v/clippings.svg
     :target: https://pypi.org/pypi/clippings
     :alt: Latest version released on PyPI

--- a/README.rst
+++ b/README.rst
@@ -37,8 +37,8 @@ Programmatic Usage
 
     from clippings import parse_clippings
 
-    my_clippings_fl = ...
-    parse_clippings(my_clippings_fl)
+    my_clippings_file = ...
+    parse_clippings(my_clippings_file)
 
 Want to parse non-English clippings?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,8 @@ Installation
 Usage
 -----
 
+Command-line Usage
+^^^^^^^^^^^^^^^^^^
 .. code:: shell
 
     # Parse a clippings file
@@ -27,6 +29,32 @@ Usage
     
     # or from stdin:
     cat clippings.txt | clippings -
+
+Programmatic Usage
+^^^^^^^^^^^^^^^^^^
+
+.. code:: py
+
+    from clippings import parse_clippings
+
+    my_clippings_fl = ...
+    parse_clippings(my_clippings_fl)
+
+Want to parse non-English clippings?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Here's a highlight clipping taken from a Kindle that speaks Spanish::
+
+    El Principe de la Niebla (Carlos Ruiz Zafón)
+    - La subrayado en la página 4 | posición 60-60 | Añadido el miércoles, 6 de julio de 2022 06:54:57
+
+    asintiendo a una pregunta que Max no había llegado a formular.
+
+``parse_clippings`` won't parse this by default but you can write your own parser for 
+the second line and pass it to the parameter ``metadata_parser``. 
+You can take a look at an example `here <examples/bilingual_spanish_english_kindle/main.py>`_.
+
+
 
 
 .. |pypi| image:: https://img.shields.io/pypi/v/clippings.svg

--- a/clippings/parser.py
+++ b/clippings/parser.py
@@ -2,6 +2,7 @@
 import argparse
 import json
 import re
+from typing import Callable
 
 import dateutil.parser
 

--- a/clippings/parser.py
+++ b/clippings/parser.py
@@ -150,7 +150,10 @@ class Clipping(BasicEqualityMixin):
         }
 
 
-def parse_clippings(clippings_file):
+def parse_clippings(
+        clippings_file,
+        document_parser: Callable[[str], Document] = Document.parse,
+        metadata_parser: Callable[[str], Metadata] = Metadata.parse):
     """Take a file containing clippings, and return a list of objects."""
 
     # Last separator not followed by an entry
@@ -161,10 +164,10 @@ def parse_clippings(clippings_file):
         lines = entry.strip().splitlines()
 
         document_line = lines[0]
-        document = Document.parse(document_line)
+        document = document_parser(document_line)
 
         metadata_line = lines[1]
-        metadata = Metadata.parse(metadata_line)
+        metadata = metadata_parser(metadata_line)
 
         content = '\n'.join(lines[3:])
 

--- a/examples/bilingual_spanish_english_kindle/en_metadata_parser.py
+++ b/examples/bilingual_spanish_english_kindle/en_metadata_parser.py
@@ -1,4 +1,6 @@
-from .utils import *
+from clippings.parser import Location
+from .utils import (Category, MetadataParsers, ParseError, bind_parsers,
+                    create_metadata_parser, date_parser, pattern_parser)
 
 
 def en_category_parser(category_str) -> Category:

--- a/examples/bilingual_spanish_english_kindle/en_metadata_parser.py
+++ b/examples/bilingual_spanish_english_kindle/en_metadata_parser.py
@@ -1,0 +1,23 @@
+from .utils import *
+
+
+def en_category_parser(category_str) -> Category:
+    for cat in Category:
+        if category_str.casefold() == cat.name.casefold():
+            return cat
+
+    raise ParseError(category_str, Category)
+
+
+en_metadata_parsers: MetadataParsers = {
+    "location": bind_parsers(
+        Location.parse,
+        pattern_parser(r'location ([\d-])+')),
+    "page": bind_parsers(int_parser, pattern_parser(r'page ([\d-])+')),
+    "timestamp": bind_parsers(
+        date_parser('%A, %d %B %Y %H:%M:%S'),
+        pattern_parser(r'Added on (.+)', True)),
+    "category": bind_parsers(en_category_parser, pattern_parser(r'Your (\w+)', True))
+}
+
+en_metadata_parser = create_metadata_parser(**en_metadata_parsers)

--- a/examples/bilingual_spanish_english_kindle/en_or_es_metadata_parser.py
+++ b/examples/bilingual_spanish_english_kindle/en_or_es_metadata_parser.py
@@ -1,0 +1,11 @@
+from .en_metadata_parser import en_metadata_parser
+from .es_metadata_parser import es_metadata_parser
+import re
+
+
+def en_or_es_metadata_parser(metadata_line: str):
+    """Parse @metadata_line in Spanish or English"""
+    if re.search("Your", metadata_line):
+        return en_metadata_parser(metadata_line)
+    else:
+        return es_metadata_parser(metadata_line)

--- a/examples/bilingual_spanish_english_kindle/es_metadata_parser.py
+++ b/examples/bilingual_spanish_english_kindle/es_metadata_parser.py
@@ -1,4 +1,6 @@
-from .utils import *
+from clippings.parser import Location
+from .utils import (Category, MetadataParsers, bind_parsers,
+                    create_metadata_parser, date_parser, pattern_parser)
 
 
 def es_category_parser(category_str) -> Category:

--- a/examples/bilingual_spanish_english_kindle/es_metadata_parser.py
+++ b/examples/bilingual_spanish_english_kindle/es_metadata_parser.py
@@ -1,0 +1,28 @@
+from .utils import *
+
+
+def es_category_parser(category_str) -> Category:
+    if category_str == 'subrayado':
+        return Category.HIGHLIGHT
+    elif category_str == 'marcador':
+        return Category.BOOKMARK
+    elif category_str == 'nota':
+        return Category.NOTE
+
+
+es_metadata_parsers: MetadataParsers = {
+    "location": bind_parsers(
+        Location.parse,
+        pattern_parser(r'posición ([\d-])+')),
+    "page": bind_parsers(int_parser, pattern_parser(r'página (\d)+')),
+    "timestamp": bind_parsers(
+        date_parser(
+            'el %A, %d de %B de %Y %H:%M:%S',
+            locale='es_ES.UTF-8'),
+        pattern_parser(r'Añadido (.+)', True)),
+    "category": bind_parsers(
+        es_category_parser,
+        pattern_parser(r'(?:El|La) (\w+)', True))
+}
+
+es_metadata_parser = create_metadata_parser(**es_metadata_parsers)

--- a/examples/bilingual_spanish_english_kindle/main.py
+++ b/examples/bilingual_spanish_english_kindle/main.py
@@ -1,0 +1,24 @@
+from sys import argv
+from pprint import pprint
+from clippings.parser import parse_clippings, main
+from .en_or_es_metadata_parser import en_or_es_metadata_parser
+
+
+def print_spanish_english_parsed_clippings(clippings_fl_path: str, out_fl_path: str):
+    """Parse @clippings_fl_path then print the result to @out_fl_path."""
+
+    with open(clippings_fl_path, encoding="utf-8") as f:
+        # Parse clippings using @en_or_es_metadata_parser
+        clippings = parse_clippings(f, metadata_parser=en_or_es_metadata_parser)
+
+        # Write parsed result to @out_fl_path
+        with open(out_fl_path, "w", encoding='utf-8') as o:
+            pprint([c.to_dict() for c in clippings], o)
+
+
+# Parse a non-English clippings file:
+#   python3 -m examples.bilingual_spanish_english_kindle.main \
+#              ./examples/bilingual_spanish_english_kindle/resources/MyClippings.txt \
+#              ./examples/bilingual_spanish_english_kindle/resources/parse_result.txt
+if __name__ == '__main__':
+    print_spanish_english_parsed_clippings(argv[1], argv[2])

--- a/examples/bilingual_spanish_english_kindle/resources/MyClippings.txt
+++ b/examples/bilingual_spanish_english_kindle/resources/MyClippings.txt
@@ -1,0 +1,11 @@
+
+The Priory of the Orange Tree (Samantha Shannon)
+- Your Highlight on page 115 | location 1756-1757 | Added on Friday, 26 February 2021 11:03:02
+
+Though she had Ersyri blood, she had not been born in the Ersyr and had not often set foot in it.
+==========
+El Principe de la Niebla (Carlos Ruiz Zafón)
+- La subrayado en la página 4 | posición 60-60 | Añadido el miércoles, 6 de julio de 2022 06:54:57
+
+asintiendo a una pregunta que Max no había llegado a formular.
+==========

--- a/examples/bilingual_spanish_english_kindle/resources/parse_result.txt
+++ b/examples/bilingual_spanish_english_kindle/resources/parse_result.txt
@@ -1,0 +1,15 @@
+[{'content': 'Though she had Ersyri blood, she had not been born in the Ersyr '
+             'and had not often set foot in it.',
+  'document': {'authors': 'Samantha Shannon',
+               'title': 'The Priory of the Orange Tree'},
+  'metadata': {'category': <Category.HIGHLIGHT: 2>,
+               'location': {'begin': 7, 'end': 7},
+               'page': 5,
+               'timestamp': datetime.datetime(2021, 2, 26, 11, 3, 2)}},
+ {'content': 'asintiendo a una pregunta que Max no había llegado a formular.',
+  'document': {'authors': 'Carlos Ruiz Zafón',
+               'title': 'El Principe de la Niebla'},
+  'metadata': {'category': <Category.HIGHLIGHT: 2>,
+               'location': {'begin': 0, 'end': 0},
+               'page': 4,
+               'timestamp': datetime.datetime(2022, 7, 6, 6, 54, 57)}}]

--- a/examples/bilingual_spanish_english_kindle/utils.py
+++ b/examples/bilingual_spanish_english_kindle/utils.py
@@ -3,7 +3,7 @@ from enum import Enum, auto
 from typing import Optional
 import re
 from datetime import datetime
-import locale as pylocale
+import locale as locale_module
 import contextlib
 from typing_extensions import Unpack
 from typing import Optional, TypedDict, Callable
@@ -37,9 +37,9 @@ class Category(Enum):
 def setlocale(*args, **kw):
     """ With thanks: https://stackoverflow.com/a/18594128
     """
-    saved = pylocale.setlocale(pylocale.LC_ALL)
-    yield pylocale.setlocale(*args, **kw)
-    pylocale.setlocale(pylocale.LC_ALL, saved)
+    saved = locale_module.setlocale(locale_module.LC_ALL)
+    yield locale_module.setlocale(*args, **kw)
+    locale_module.setlocale(locale_module.LC_ALL, saved)
 
 
 def pattern_parser(pattern, raise_parse_failure=False):
@@ -56,7 +56,7 @@ def pattern_parser(pattern, raise_parse_failure=False):
 def date_parser(date_format, locale=None):
     def parser(s: str):
         if locale:
-            with setlocale(pylocale.LC_TIME, locale):
+            with setlocale(locale_module.LC_TIME, locale):
                 return datetime.strptime(s, date_format)
         else:
             return datetime.strptime(s, date_format)

--- a/examples/bilingual_spanish_english_kindle/utils.py
+++ b/examples/bilingual_spanish_english_kindle/utils.py
@@ -1,0 +1,98 @@
+from parser import ParserError
+from enum import Enum, auto
+from typing import Optional
+import re
+from datetime import datetime
+import locale as pylocale
+import contextlib
+from typing_extensions import Unpack
+from typing import Optional, TypedDict, Callable
+from clippings.parser import Metadata, Location
+
+
+class ParseError(Exception):
+    def __init__(self, string, parsing_as):
+        super().__init__(f"Failed to parse {string} as {parsing_as}")
+
+
+class Category(Enum):
+    """
+    Category allows users to normalise the result of metadata line parsing 
+    across languages.
+
+    For example, the metadata lines
+
+    "- La subrayado en la página 4 | posición 60-60 | Añadido el miércoles, 6 de julio de 2022 06:54:57" 
+    "- Your Highlight on page 4 | location 60-60 | Added on Wednesday, 6 July 2022 06:54:57" 
+
+    represent the same highlight but in different languages, so we may wish to 
+    parse them both as { "category": Category.HIGHLIGHT, ... }.
+    """
+    NOTE = auto()
+    HIGHLIGHT = auto()
+    BOOKMARK = auto()
+
+
+@contextlib.contextmanager
+def setlocale(*args, **kw):
+    """ With thanks: https://stackoverflow.com/a/18594128
+    """
+    saved = pylocale.setlocale(pylocale.LC_ALL)
+    yield pylocale.setlocale(*args, **kw)
+    pylocale.setlocale(pylocale.LC_ALL, saved)
+
+
+def pattern_parser(pattern, raise_parse_failure=False):
+    def parser(s: str) -> Optional[str]:
+        match = re.search(pattern, s)
+        if match:
+            return match.group(1)
+        elif raise_parse_failure:
+            raise ParseError(s, str)
+
+    return parser
+
+
+def date_parser(date_format, locale=None):
+    def parser(s: str):
+        if locale:
+            with setlocale(pylocale.LC_TIME, locale):
+                return datetime.strptime(s, date_format)
+        else:
+            return datetime.strptime(s, date_format)
+
+    return parser
+
+
+def int_parser(s: str):
+    try:
+        return int(s)
+    except TypeError:
+        return None
+
+
+def bind_parsers(parser1, parser2):
+    def parser(s: str):
+        res = parser2(s)
+        if res:
+            return parser1(res)
+
+    return parser
+
+
+class MetadataParsers(TypedDict):
+    category: Callable[[str], str]
+    page: Callable[[str], Optional[int]]
+    location: Callable[[str], Location]
+    timestamp: Callable[[str], datetime]
+
+
+def create_metadata_parser(**parsers: Unpack[MetadataParsers]):
+    def parser(metadata_line: str):
+        return Metadata(
+            category=parsers['category'](metadata_line),
+            location=parsers['location'](metadata_line),
+            timestamp=parsers['timestamp'](metadata_line),
+            page=parsers['page'](metadata_line))
+
+    return parser

--- a/tests/parser_test.py
+++ b/tests/parser_test.py
@@ -397,6 +397,22 @@ def fixture_parsed_clippings(clippings_filename):
     return clippings
 
 
+def test_parse_clippings_parser_params(clippings_filename, document, metadata):
+    clippings_file_path = os.path.join(TEST_RESOURCES_DIR, clippings_filename)
+    def document_parser(_): return document
+    def metadata_parser(_): return metadata
+
+    with open(clippings_file_path, 'r') as clippings_file:
+        clippings = parse_clippings(
+            clippings_file,
+            document_parser=document_parser,
+            metadata_parser=metadata_parser)
+
+    assert len(clippings) != 0
+    assert clippings[0].document == document
+    assert clippings[0].metadata == metadata
+
+
 def test_parse_clippings_file_to_json(parsed_clippings):
     results_file_path = os.path.join(TEST_RESOURCES_DIR, 'clippings.json')
     with open(results_file_path) as results_file:


### PR DESCRIPTION
Adds flexibility by allowing users to provide their own parsers for the document and metadata lines. Includes an example of providing a parser for metadata lines in English or Spanish.