### PR TITLE
A parser::Document optionally has authors

### DIFF
--- a/clippings/parser.py
+++ b/clippings/parser.py
@@ -21,13 +21,16 @@ class Document(BasicEqualityMixin):
 
     PATTERN = re.compile(r'^(?P<title>.+) \((?P<authors>.+?)\)$')
 
-    def __init__(self, title, authors):
+    def __init__(self, title, authors=None):
         self.title = title
         self.authors = authors
 
     def __str__(self):
-        return '{title} ({authors})'.format(title=self.title,
-                                            authors=self.authors)
+        if self.authors:
+            return '{title} ({authors})'.format(title=self.title,
+                                                authors=self.authors)
+        else:
+            return self.title
 
     def to_dict(self):
         return self.__dict__
@@ -35,9 +38,10 @@ class Document(BasicEqualityMixin):
     @classmethod
     def parse(cls, line):
         match = re.match(cls.PATTERN, line)
-        title = match.group('title')
-        authors = match.group('authors')
-        return cls(title, authors)
+        if match:
+            return cls(match.group('title'), match.group('authors'))
+        else:
+            return cls(line, None)
 
 
 class Location(BasicEqualityMixin):

--- a/tests/parser_test.py
+++ b/tests/parser_test.py
@@ -50,9 +50,34 @@ def fixture_document_as_dict(document_title, document_authors):
     }
 
 
+@pytest.fixture(name='document_no_authors')
+def fixture_document_no_authors(document_title):
+    return Document(
+        title=document_title
+    )
+
+
+@pytest.fixture(name='document_no_authors_as_str')
+def fixture_document_no_authors_as_str():
+    return '1984'
+
+
+@pytest.fixture(name='document_no_authors_as_dict')
+def fixture_document_no_authors_as_dict(document_title):
+    return {
+        'title': document_title,
+        'authors': None,
+    }
+
+
 def test_create_document(document, document_title, document_authors):
     assert document.title == document_title
     assert document.authors == document_authors
+
+
+@pytest.mark.parametrize('document_authors', [None])
+def test_create_document_no_authors(document, document_title, document_authors):
+    test_create_document(document, document_title, document_authors)
 
 
 def test_parse_document(document_as_str, document_title, document_authors):
@@ -61,12 +86,27 @@ def test_parse_document(document_as_str, document_title, document_authors):
     assert document.title == document_title
 
 
+@pytest.mark.parametrize('document_authors', [None])
+def test_parse_document_no_authors(document_no_authors_as_str, document_title, document_authors):
+    test_parse_document(document_no_authors_as_str, document_title, document_authors)
+
+
 def test_document_to_string(document, document_as_str):
     assert str(document) == document_as_str
 
 
+@pytest.mark.parametrize('document_authors', [None])
+def test_document_no_authors_to_string(document, document_no_authors_as_str):
+    test_document_to_string(document, document_no_authors_as_str)
+
+
 def test_document_to_dict(document, document_as_dict):
     assert document.to_dict() == document_as_dict
+
+
+@pytest.mark.parametrize('document_authors', [None])
+def test_document_no_authors_to_dict(document, document_no_authors_as_dict):
+    test_document_to_dict(document, document_no_authors_as_dict)
 
 
 def test_document_equality_same_values(document, document_as_dict):


### PR DESCRIPTION
Modify `Document.__str__` and `Document.parse` to allow working with document title lines that don't include an author, which often occurs when using a Kindle to read PDFs.